### PR TITLE
Use GITHUB_API_TOKEN naming instead of OAUTH_TOKEN

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -3,8 +3,8 @@ set -e
 
 release_path="https://api.github.com/repos/starship/starship/releases"
 cmd="curl -s"
-if [  -n "$OAUTH_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $OAUTH_TOKEN'"
+if [  -n "$GITHUB_API_TOKEN" ]; then
+  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
 fi
 cmd="$cmd $release_path"
 


### PR DESCRIPTION
This switch is to align with asdf documentation: https://asdf-vm.com/#/plugins-create?id=github-api-rate-limiting