### PR TITLE
Install binary compiled with musl to support older Linux distros

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -10,7 +10,7 @@ case "$(uname -s)" in
 		DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-x86_64-apple-darwin.tar.gz"
 		;;
 	"Linux")
-		DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-x86_64-unknown-linux-gnu.tar.gz"
+		DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-x86_64-unknown-linux-musl.tar.gz"
 		;;
 esac
 


### PR DESCRIPTION
Current asdf-starship installs starship binary compiled with glibc and may not work in older Linux distributions such as CentOS 7 or Ubuntu 16.04.
https://starship.rs/faq/#how-do-i-run-starship-on-linux-distributions-with-older-versions-of-glibc

This PR installs binary compiled with musl instead of glibc to support these older distributions.

