### PR TITLE
ci: modernize asdf plugin CI and tidy plugin setup

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ]
 }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Main workflow
+name: Build
 
 on:
   push:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,30 @@
+name: Lint
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install shellcheck and shfmt
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
+      - name: Run lint
+        run: ./scripts/lint.bash
+
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.7.7
+        with:
+          args: -color

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -11,15 +11,18 @@ on:
     - cron: "0 0 * * 5"
 
 jobs:
-  build:
+  plugin_test:
+    name: asdf plugin test
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest]
+        os:
+          - ubuntu-latest
+          - macos-latest
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: asdf plugin test
-        uses: asdf-vm/actions/plugin-test@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
+        uses: asdf-vm/actions/plugin-test@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
         with:
           command: starship --version

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+shellcheck 0.10.0
+shfmt 3.10.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # asdf-starship
 
-[![Main workflow](https://github.com/gr1m0h/asdf-starship/actions/workflows/workflow.yaml/badge.svg)](https://github.com/gr1m0h/asdf-starship/actions/workflows/workflow.yaml)
+[![Build](https://github.com/gr1m0h/asdf-starship/actions/workflows/build.yaml/badge.svg)](https://github.com/gr1m0h/asdf-starship/actions/workflows/build.yaml)
 [![Lint](https://github.com/gr1m0h/asdf-starship/actions/workflows/lint.yaml/badge.svg)](https://github.com/gr1m0h/asdf-starship/actions/workflows/lint.yaml)
 
 [Starship](https://github.com/starship/starship) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,62 @@
-[![GitHub Actions Status](https://github.com/gr1m0h/asdf-starship/workflows/Main%20workflow/badge.svg?branch=main)](https://github.com/gr1m0h/asdf-starship/actions)
-
 # asdf-starship
 
-[Starship](https://github.com/starship/starship) plugin for [asdf](https://github.com/asdf-vm/asdf) version manager
+[![Main workflow](https://github.com/gr1m0h/asdf-starship/actions/workflows/workflow.yaml/badge.svg)](https://github.com/gr1m0h/asdf-starship/actions/workflows/workflow.yaml)
+[![Lint](https://github.com/gr1m0h/asdf-starship/actions/workflows/lint.yaml/badge.svg)](https://github.com/gr1m0h/asdf-starship/actions/workflows/lint.yaml)
 
-## Installation
+[Starship](https://github.com/starship/starship) plugin for the [asdf](https://github.com/asdf-vm/asdf) version manager.
 
-Install the plugin:
+## Install
 
+```shell
+asdf plugin add starship https://github.com/gr1m0h/asdf-starship.git
 ```
-asdf plugin add starship
+
+## Usage
+
+See the [asdf documentation](https://asdf-vm.com/manage/core.html) for the full
+set of commands. The most common ones are:
+
+```shell
+# Show all installable versions
+asdf list all starship
+
+# Install a specific version
+asdf install starship latest
+asdf install starship 1.24.0
+
+# Set a version globally (writes to ~/.tool-versions)
+asdf set -u starship latest
+
+# Set a version for the current project (writes to ./.tool-versions)
+asdf set starship 1.24.0
 ```
 
-Add the init script to your shell's config file:
-* For more details: [Starship Installation](https://starship.rs/guide/#%F0%9F%9A%80-installation)
+Then add the init script to your shell's config file. See the
+[Starship installation guide](https://starship.rs/guide/#%F0%9F%9A%80-installation)
+for details.
+
+## Contributing
+
+Contributions are welcome! This plugin is linted with
+[shellcheck](https://www.shellcheck.net/) and
+[shfmt](https://github.com/mvdan/sh), and tested with
+[asdf-vm/actions](https://github.com/asdf-vm/actions).
+
+The required tooling versions are pinned in [`.tool-versions`](./.tool-versions),
+so you can install them with asdf:
+
+```shell
+asdf install
+```
+
+```shell
+# Format the shell scripts
+./scripts/format.bash
+
+# Lint the shell scripts
+./scripts/lint.bash
+```
+
+## License
+
+[MIT](./LICENSE)

--- a/bin/download
+++ b/bin/download
@@ -6,29 +6,29 @@ set -e
 [ -n "$ASDF_DOWNLOAD_PATH" ] || (echo 'Missing ASDF_DOWNLOAD_PATH' >&2 && exit 1)
 
 case "$(uname -s)" in
-  "Darwin")
-    case "$(uname -m)" in
-      "arm64")
-        DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-aarch64-apple-darwin.tar.gz"
-        ;;
-      "x86_64")
-        DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-x86_64-apple-darwin.tar.gz"
-        ;;
-    esac
-    ;;
-  "Linux")
-    case "$(uname -m)" in
-      "armv7l")
-        DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-arm-unknown-linux-musleabihf.tar.gz"
-        ;;
-      "x86_64")
-        DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-x86_64-unknown-linux-musl.tar.gz"
-        ;;
-      "aarch64")
-        DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-aarch64-unknown-linux-musl.tar.gz"
-        ;;
-    esac
-    ;;
+"Darwin")
+	case "$(uname -m)" in
+	"arm64")
+		DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-aarch64-apple-darwin.tar.gz"
+		;;
+	"x86_64")
+		DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-x86_64-apple-darwin.tar.gz"
+		;;
+	esac
+	;;
+"Linux")
+	case "$(uname -m)" in
+	"armv7l")
+		DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-arm-unknown-linux-musleabihf.tar.gz"
+		;;
+	"x86_64")
+		DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-x86_64-unknown-linux-musl.tar.gz"
+		;;
+	"aarch64")
+		DOWNLOAD_URL="https://github.com/starship/starship/releases/download/v${ASDF_INSTALL_VERSION}/starship-aarch64-unknown-linux-musl.tar.gz"
+		;;
+	esac
+	;;
 esac
 
 curl -fL -o "${ASDF_DOWNLOAD_PATH}/starship.tar.gz" "${DOWNLOAD_URL}"

--- a/bin/list-all
+++ b/bin/list-all
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
-set -e
+
+set -euo pipefail
 
 release_path="https://api.github.com/repos/starship/starship/releases"
-cmd="curl -s"
-if [  -n "$GITHUB_API_TOKEN" ]; then
-  cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
-fi
-cmd="$cmd $release_path"
 
-versions=$(eval $cmd | sed -nE 's/^    "tag_name": "v(.+)",$/\1/pg' | sed -n -e '1!G;h;$p')
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+	response=$(curl -s -H "Authorization: token ${GITHUB_API_TOKEN}" "$release_path")
+else
+	response=$(curl -s "$release_path")
+fi
+
+versions=$(printf '%s\n' "$response" |
+	sed -nE 's/^    "tag_name": "v(.+)",$/\1/pg' |
+	sed -n -e '1!G;h;$p')
+
+# asdf expects all versions on a single, space-separated line, so the
+# word-splitting performed by an unquoted expansion is intentional here.
+# shellcheck disable=SC2086
 echo $versions

--- a/scripts/format.bash
+++ b/scripts/format.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+shfmt --language-dialect bash --write \
+	bin/* scripts/*

--- a/scripts/lint.bash
+++ b/scripts/lint.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+shellcheck --shell=bash --external-sources \
+	bin/* \
+	scripts/*
+
+shfmt --language-dialect bash --diff \
+	bin/* scripts/*


### PR DESCRIPTION
## Overview

Runs the latest asdf plugin CI and gives the plugin a clean, conventional setup.

## CI

- **Bump `asdf-vm/actions/plugin-test` to `v4.0.1`** (pinned by SHA `b7bcd02`). v4.0.x supports asdf >= 0.16.0, and `v4.0.1` specifically fixes the "prefer branch name when seeding plugin git ref" bug that broke the earlier `v4.0.0` bump (the renovate run that was reverted in #36). The matrix now uses lowercase `macos-latest`.
- **New `Lint` workflow** running `shellcheck` + `shfmt` (installed via asdf) and `actionlint`, following the [asdf plugin template](https://github.com/asdf-vm/asdf-plugin-template) conventions.

## Plugin setup

- Add `scripts/lint.bash` and `scripts/format.bash`.
- Pin dev tooling in `.tool-versions` (`shellcheck`, `shfmt`) so contributors can `asdf install` the exact versions CI uses.
- Make `bin/list-all` shellcheck-clean by dropping `eval`, **while preserving the single-line, space-separated output asdf expects** — keeping the fix for the `latest` resolution regression (#33). Verified against sample GitHub API JSON: output is oldest→newest with the newest as the last token.
- Reformat `bin/*` with `shfmt`.

## Housekeeping

- Modernize the renovate config: `config:base` → `config:recommended` and pin GitHub Action digests.
- Refresh the README with workflow badges, usage examples, and a contributing section.

## Verification

Locally, with the same tool flags CI uses:

- `./scripts/lint.bash` — passes (shellcheck + shfmt across `bin/*` and `scripts/*`)
- `actionlint .github/workflows/*.yaml` — passes
- `bin/list-all` parsing verified on realistic GitHub API JSON (latest = last token)

CI on this branch will exercise the v4.0.1 plugin-test and the new lint workflow.

https://claude.ai/code/session_01WYLgdbHtKKvZD9ooEDXPxt

---
_Generated by [Claude Code](https://claude.ai/code/session_01WYLgdbHtKKvZD9ooEDXPxt)_