### PR TITLE
chore: update pinned tooling to latest secure versions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,6 +25,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check workflow files
-        uses: docker://rhysd/actionlint:1.7.7
+        uses: docker://rhysd/actionlint:1.7.12
         with:
           args: -color

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-shellcheck 0.10.0
-shfmt 3.10.0
+shellcheck 0.11.0
+shfmt 3.13.1


### PR DESCRIPTION
## Summary

asdf-starship is the reference standard for the other plugins, but a few pinned versions had fallen behind. This brings the linting toolchain up to the latest releases.

- `.tool-versions`: shellcheck `0.10.0` → `0.11.0`, shfmt `3.10.0` → `3.13.1`
- `lint.yaml`: actionlint `1.7.7` → `1.7.12`

GitHub Actions remain pinned by commit SHA, and renovate (`helpers:pinGitHubActionDigests`) will keep digests fresh going forward.

## Verification

- `shellcheck 0.11.0` and `shfmt 3.13.1` run clean over `bin/*` and `scripts/*`
- `actionlint 1.7.12` passes on all workflow files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0138jGwAzH9S7zNhjGZjPy5T)_